### PR TITLE
Temporarily switch to C locale in order to determine commands...

### DIFF
--- a/plugin/headlights.vim
+++ b/plugin/headlights.vim
@@ -228,9 +228,19 @@ function! s:GetVimCommandOutput(command) " {{{1
   " (try-catch doesn't always work here, for some reason)
   let l:output = ''
 
+  " temporarily switch messages to default locale since HL_SOURCE_LINE relies on it
+  let l:lang = v:lang
+  if match(l:lang, "\\(C$\\|en\\($\\|_\\)\\)") != 0
+    execute "silent language messages C"
+  endif
+
   redir => l:output
     execute "silent verbose " . a:command
   redir END
+
+  if l:lang != v:lang
+    execute "silent language messages " . l:lang
+  endif
 
   return l:output
 endfunction


### PR DESCRIPTION
... if a locale other than "C" or "en_*" is detected. This fixes the menus in international environments (for the price of adding two bogus submenus "exec_menuitem" and "menu_<LOCALE>").
